### PR TITLE
Previous meetings and registration site

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -11,3 +11,6 @@ mail_url: mailto:meetup@bsd-pl.org
 facebook_url: https://www.facebook.com/pg/The-Polish-BSD-User-Group-2104511872897332
 twitter_url: https://twitter.com/BSD_PL
 youtube_url: https://www.youtube.com/channel/UCWvDQaEHSULuCIVOOM66nYA
+
+# Link to the current registration site.
+registration_url: https://bit.ly/bsd-pl-8

--- a/_layouts/meetup.html
+++ b/_layouts/meetup.html
@@ -1,8 +1,8 @@
 ---
 layout: default
 ---
-{% assign meetup-number = page.permalink | split: '/' | last: %}
+{% assign meetup-number = page.permalink | split: '/' %}
 
-<h1>Meetup #{{ meetup-number }}</h1>
+<h1>Meetup #{{ meetup-number.last }}</h1>
 
 {{ content }}

--- a/_layouts/meetup.html
+++ b/_layouts/meetup.html
@@ -1,0 +1,8 @@
+---
+layout: default
+---
+{% assign meetup-number = page.permalink | split: '/' | last: %}
+
+<h1>Meetup #{{ meetup-number }}</h1>
+
+{{ content }}

--- a/meetup-1-pl.md
+++ b/meetup-1-pl.md
@@ -1,0 +1,27 @@
+---
+title: "Polish BSD User Group: Meetup #1"
+layout: meetup
+permalink: /meetups/1
+---
+Kiedy:
+<pre>
+24 Maja 2018 r.
+18:30 - 21:00
+</pre>
+Gdzie:
+<pre>
+Wheel Systems
+Aleje Jerozolimskie 178
+Warszawa
+</pre>
+O czym:
+<pre>
+Introduction to the FreeBSD Project.
+Konrad Witaszczyk
+
+Checkpoints in ZFS.
+Mariusz Zaborski
+
+Qubes OS.
+Wojtek Porczyk
+</pre>

--- a/meetup-1.md
+++ b/meetup-1.md
@@ -1,0 +1,27 @@
+---
+title: "Polish BSD User Group: Meetup #1"
+layout: meetup
+permalink: /en/meetups/1
+---
+When:
+<pre>
+May 24 2018
+18:30 - 21:00
+</pre>
+Where:
+<pre>
+Wheel Systems Office
+Aleje Jerozolimskie 178
+Warsaw
+</pre>
+What:
+<pre>
+Introduction to the FreeBSD Project.
+Konrad Witaszczyk
+
+Checkpoints in ZFS.
+Mariusz Zaborski
+
+Qubes OS.
+Wojtek Porczyk
+</pre>

--- a/meetup-2-pl.md
+++ b/meetup-2-pl.md
@@ -1,0 +1,30 @@
+---
+title: "Polish BSD User Group: Meetup #2"
+layout: meetup
+permalink: /meetups/2
+---
+Kiedy:
+<pre>
+27 Czerwca 2018 r.
+18:30 - 21:00
+</pre>
+Gdzie:
+<pre>
+Wheel Systems
+Aleje Jerozolimskie 178
+Warszawa
+</pre>
+O czym:
+<pre>
+YubiKey dla użytkowników FreeBSD
+Jarosław Żurek
+
+System FreeBSD w IETiSIP PW
+Andrzej Toboła
+
+ZeroTrust Initiative
+Paweł Jakub Dawidek
+
+Monitoring - niezbędnik w pracy admina
+Kamil Czekirda
+</pre>

--- a/meetup-2.md
+++ b/meetup-2.md
@@ -1,0 +1,30 @@
+---
+title: "Polish BSD User Group: Meetup #2"
+layout: meetup
+permalink: /en/meetups/2
+---
+When:
+<pre>
+June 27 2018
+18:30 - 21:00
+</pre>
+Where:
+<pre>
+Wheel Systems Office
+Aleje Jerozolimskie 178
+Warsaw
+</pre>
+What:
+<pre>
+YubiKey for FreeBSD users
+Jarosław Żurek
+
+FreeBSD System at IETiSIP PW
+Andrzej Toboła
+
+ZeroTrust Initiative
+Paweł Jakub Dawidek
+
+Monitoring - administrator's toolkit
+Kamil Czekirda
+</pre>

--- a/meetup-3-pl.md
+++ b/meetup-3-pl.md
@@ -1,0 +1,27 @@
+---
+title: "Polish BSD User Group: Meetup #3"
+layout: meetup
+permalink: /meetups/3
+---
+Kiedy:
+<pre>
+30 lipca 2018 r.
+18:30 - 21:00
+</pre>
+Gdzie:
+<pre>
+Wheel Systems Office
+Aleje Jerozolimskie 178
+Warszawa
+</pre>
+O czym:
+<pre style="white-space: pre-wrap;">
+Jak skonfigurować scentralizowane uwierzytelnianie (ssh i sudo) za pomocą oprogramowania FreeIPA w systemie FreeBSD.
+Krzysztof Toczyski
+
+ZFS Boot Environments
+Sławomir Wojciech Wojtczak (vermaden)
+
+Komputery zależnościowe w systemach sterowania ruchem kolejowym
+Michał Jędrzejczak
+</pre>

--- a/meetup-3.md
+++ b/meetup-3.md
@@ -1,0 +1,27 @@
+---
+title: "Polish BSD User Group: Meetup #3"
+layout: meetup
+permalink: /en/meetups/3
+---
+When:
+<pre>
+July 30 2018
+18:30 - 21:00
+</pre>
+Where:
+<pre>
+Wheel Systems Office
+Aleje Jerozolimskie 178
+Warsaw
+</pre>
+What:
+<pre style="white-space: pre-wrap;">
+How to configure centralized authentication (ssh and sudo) with FreeIPA software on FreeBSD system.
+Krzysztof Toczyski
+
+ZFS Boot Environments
+Sławomir Wojciech Wojtczak (vermaden)
+
+Vital computer in train control systems.
+Michał Jędrzejczak
+</pre>

--- a/meetup-4-pl.md
+++ b/meetup-4-pl.md
@@ -1,0 +1,24 @@
+---
+title: "Polish BSD User Group: Meetup #5"
+layout: meetup
+permalink: /meetups/4
+---
+Kiedy:
+<pre>
+9 sierpnia 2018 r.
+18:30 - 21:00
+</pre>
+Gdzie:
+<pre>
+Wheel Systems Office
+Aleje Jerozolimskie 178
+Warszawa
+</pre>
+O czym:
+<pre style="white-space: pre-wrap;">
+DTrace dla deweloperów
+George Neville-Neil
+
+RIO 2014 – jak się robi dużą transmisję internetową
+Rafał Wiosna
+</pre>

--- a/meetup-4.md
+++ b/meetup-4.md
@@ -1,0 +1,24 @@
+---
+title: "Polish BSD User Group: Meetup #5"
+layout: meetup
+permalink: /en/meetups/4
+---
+When:
+<pre>
+August 9 2018
+18:30 - 21:00
+</pre>
+Where:
+<pre>
+Wheel Systems Office
+Aleje Jerozolimskie 178
+Warsaw
+</pre>
+What:
+<pre style="white-space: pre-wrap;">
+DTrace for Developers
+George Neville-Neil
+
+FIFA World Cup Finals – how to put one on the Internet
+Rafał Wiosna
+</pre>

--- a/meetup-5-pl.md
+++ b/meetup-5-pl.md
@@ -1,0 +1,27 @@
+---
+title: "Polish BSD User Group: Meetup #5"
+layout: meetup
+permalink: /meetups/5
+---
+Kiedy:
+<pre>
+13 września 2018 r.
+18:30 - 21:00
+</pre>
+Gdzie:
+<pre>
+Wheel Systems Office
+Aleje Jerozolimskie 178
+Warszawa
+</pre>
+O czym:
+<pre style="white-space: pre-wrap;">
+BSDCam 2018 Recap
+Konrad Witaszczyk
+
+OpenBSD Daily
+Adam Wołk
+
+Patryk "Keijo" Jaworski
+Dlaczego ARM to często platforma drugiego sortu
+</pre>

--- a/meetup-5.md
+++ b/meetup-5.md
@@ -1,0 +1,27 @@
+---
+title: "Polish BSD User Group: Meetup #5"
+layout: meetup
+permalink: /en/meetups/5
+---
+When:
+<pre>
+September 13, 2018
+18:30 - 21:00
+</pre>
+Where:
+<pre>
+Wheel Systems Office
+Aleje Jerozolimskie 178
+Warsaw
+</pre>
+What:
+<pre style="white-space: pre-wrap;">
+BSDCam 2018 Recap
+Konrad Witaszczyk
+
+OpenBSD Daily
+Adam Wołk
+
+Why is ARM a Tier 2 platform?
+Patryk "Keijo" Jaworski
+</pre>

--- a/meetup-6-pl.md
+++ b/meetup-6-pl.md
@@ -1,0 +1,32 @@
+---
+title: "Polish BSD User Group: Meetup #6"
+layout: meetup
+permalink: /meetups/6
+---
+Kiedy:
+<pre>
+11 października 2018 r.
+18:15 - 21:15
+</pre>
+Gdzie:
+<pre>
+Politechnika Warszawska
+Wydział Elektryczny
+
+ul. Koszykowa 75
+Warszawa
+</pre>
+O czym:
+<pre style="white-space: pre-wrap;">
+BSD-PL 0.5. Pół-urodziny grupy.
+Krzysztof Szczepański
+
+Krótka historia czasu we FreeBSD.
+Miłosz Kaniewski
+
+Czym właściwie są kontenery?
+Maciej Pasternacki
+
+Project Cardigan - Deep Learning Based Image Retrieval
+Mariusz Wołoszyn
+</pre>

--- a/meetup-6.md
+++ b/meetup-6.md
@@ -1,0 +1,32 @@
+---
+title: "Polish BSD User Group: Meetup #6"
+layout: meetup
+permalink: /en/meetups/6
+---
+When:
+<pre>
+October 11, 2018
+18:15 - 21:15
+</pre>
+Where:
+<pre>
+Warsaw University of Technology
+Faculty of Electrical Engineering
+
+ul. Koszykowa 75
+Warsaw
+</pre>
+What:
+<pre style="white-space: pre-wrap;">
+BSD-PL 0.5. Usergroup Half-birthday.
+Krzysztof Szczepański
+
+A Brief History of Time in FreeBSD.
+Miłosz Kaniewski
+
+What are containers anyway?
+Maciej Pasternacki
+
+Project Cardigan - Deep Learning Based Image Retrieval
+Mariusz Wołoszyn
+</pre>

--- a/meetup-7-pl.md
+++ b/meetup-7-pl.md
@@ -1,0 +1,31 @@
+---
+title: "Polish BSD User Group: Meetup #7"
+layout: meetup
+permalink: /meetups/7
+---
+Kiedy:
+<pre>
+15 listopada 2018 r.
+18:30 - 21:00
+</pre>
+Gdzie:
+<pre>
+Wheel Systems Office
+
+Aleje Jerozolimskie 178
+Warszawa
+</pre>
+O czym:
+<pre style="white-space: pre-wrap;">
+GELI - Disk encryption in FreeBSD
+Michał Borysiak
+
+OpenBSD Gaming
+Adam Wołk
+
+Hello Mr. Jenkins
+Michał Mróz
+
+Unbound & FreeBSD
+Pablo Carboni
+</pre>

--- a/meetup-7.md
+++ b/meetup-7.md
@@ -1,0 +1,31 @@
+---
+title: "Polish BSD User Group: Meetup #7"
+layout: meetup
+permalink: /en/meetups/7
+---
+When:
+<pre>
+November 15, 2018
+18:30 - 21:00
+</pre>
+Where:
+<pre>
+Wheel Systems Office
+
+Aleje Jerozolimskie 178
+Warsaw
+</pre>
+What:
+<pre style="white-space: pre-wrap;">
+GELI - Disk encryption in FreeBSD
+Michał Borysiak
+
+OpenBSD Gaming
+Adam Wołk
+
+Hello Mr. Jenkins
+Michał Mróz
+
+Unbound & FreeBSD
+Pablo Carboni
+</pre>

--- a/meetup-8-pl.md
+++ b/meetup-8-pl.md
@@ -1,0 +1,31 @@
+---
+title: "Polish BSD User Group: Meetup #8"
+layout: meetup
+permalink: /meetups/8
+---
+Kiedy:
+<pre>
+13 grudnia 2018 r.
+18:15 - 21:00
+</pre>
+Gdzie:
+<pre>
+Wheel Systems Office
+
+Aleje Jerozolimskie 178
+Warszawa
+</pre>
+O czym:
+<pre style="white-space: pre-wrap;">
+FreeNAS na microserver gen8, czyli o czym zapomniał powiedzieć producent
+Kamil Czekirda
+
+FreeBSD PAM: programowanie własnych modułów uwierzytelniania
+Jarek Żurek
+
+Pisanie testów we frameworku PyTest
+Aleksander Kołowski
+
+FreeBSD Foundation
+Deb Goodkin
+</pre>

--- a/meetup-8.md
+++ b/meetup-8.md
@@ -1,0 +1,31 @@
+---
+title: "Polish BSD User Group: Meetup #7"
+layout: meetup
+permalink: /en/meetups/8
+---
+When:
+<pre>
+December 13, 2018
+18:15 - 21:00
+</pre>
+Where:
+<pre>
+Wheel Systems Office
+
+Aleje Jerozolimskie 178
+Warsaw
+</pre>
+What:
+<pre style="white-space: pre-wrap;">
+FreeNAS on microserver gen8
+Kamil Czekirda
+
+FreeBSD PAM: programming own authentication modules
+Jarek Żurek
+
+Testing with PyTest
+Aleksander Kołowski
+
+FreeBSD Foundation
+Deb Goodkin
+</pre>

--- a/readme-pl.md
+++ b/readme-pl.md
@@ -23,7 +23,7 @@ Sesja treningowa: iocage
 
 </pre>
 
-<a href="https://bit.ly/bsd-pl-8">Rejestracja</a>
+<a href="/registration">Rejestracja</a>
 
 Do zobaczenia!
 

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ Training session: iocage
 
 </pre>
 
-<a href="https://bit.ly/bsd-pl-8">Click to register</a>
+<a href="/registration">Click to register</a>
 
 See you there!
 

--- a/registration.html
+++ b/registration.html
@@ -1,0 +1,10 @@
+---
+layout: default
+title: "Polish BSD User Group - Registration"
+permalink: /registration
+---
+<script>
+	window.location = "{{ site.registration_url }}"
+</script>
+
+<a href="{{ site.registration_url }}">Registration link</a>


### PR DESCRIPTION
Previous meetings are available on `/meetings/{nr}` and `/en/meetings/`.
Registration site automatically redirects to the current registration page using JavaScript redirection.